### PR TITLE
Avoid activating magnifier windows

### DIFF
--- a/magnify_noui.cpp
+++ b/magnify_noui.cpp
@@ -178,8 +178,13 @@ using SetForegroundWindow_t = decltype(&SetForegroundWindow);
 SetForegroundWindow_t SetForegroundWindow_Original;
 
 BOOL WINAPI SetForegroundWindow_Hook(HWND hWnd) {
-    // Never bring magnifier windows to foreground
-    return TRUE;
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hWnd, &processId);
+    if (processId == GetCurrentProcessId()) {
+        // Suppress activation for magnifier windows
+        return TRUE;
+    }
+    return SetForegroundWindow_Original(hWnd);
 }
 
 // Hook SetActiveWindow 
@@ -187,8 +192,13 @@ using SetActiveWindow_t = decltype(&SetActiveWindow);
 SetActiveWindow_t SetActiveWindow_Original;
 
 HWND WINAPI SetActiveWindow_Hook(HWND hWnd) {
-    // Never activate magnifier windows
-    return NULL;
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hWnd, &processId);
+    if (processId == GetCurrentProcessId()) {
+        // Suppress activation for magnifier windows
+        return NULL;
+    }
+    return SetActiveWindow_Original(hWnd);
 }
 
 // Hook SetFocus
@@ -196,8 +206,13 @@ using SetFocus_t = decltype(&SetFocus);
 SetFocus_t SetFocus_Original;
 
 HWND WINAPI SetFocus_Hook(HWND hWnd) {
-    // Never focus magnifier windows
-    return NULL;
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hWnd, &processId);
+    if (processId == GetCurrentProcessId()) {
+        // Suppress focusing for magnifier windows
+        return NULL;
+    }
+    return SetFocus_Original(hWnd);
 }
 
 BOOL Wh_ModInit() {


### PR DESCRIPTION
## Summary
- Avoid bringing magnifier-owned windows to the foreground
- Preserve activation for other processes by calling the original functions

## Testing
- `x86_64-w64-mingw32-g++ -shared -o magnify_noui.dll magnify_noui.cpp -luser32 -lkernel32` *(fails: 'Wh_SetFunctionHook' was not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68ba54116eb8832ba384e60e21cd7b47