### PR TITLE
Hide Magnifier windows by title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 Magnifier Headless Mode
 
-Windhawk mod that hides the Magnifier user interface window
-named "Büyüteç", leaving only the zoom functionality active.
+Windhawk mod that hides the Magnifier user interface window named "Büyüteç" or "Magnifier", leaving only the zoom functionality active.

--- a/magnify_noui.cpp
+++ b/magnify_noui.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              magnifier-headless-mode
 // @name            Magnifier Headless Mode
-// @description     Blocks all Magnifier window creation, keeping only zoom functionality
-// @version         0.0.1test2
+// @description     Hides the Magnifier interface window named "Büyüteç" or "Magnifier"
+// @version         0.1
 // @author          BCRTVKCS
 // @github          bcrtvkcs
 // @twitter         bcrtvkcs
@@ -11,3 +11,73 @@
 // @exclude         ^(?!.*magnify.exe)
 // @compilerOptions -luser32 -lkernel32
 // ==/WindhawkMod==
+
+#include <windhawk.h>
+#include <windows.h>
+
+static bool ShouldHideTitle(LPCWSTR title) {
+    if (!title) {
+        return false;
+    }
+    return wcscmp(title, L"Magnifier") == 0 || wcscmp(title, L"Büyüteç") == 0;
+}
+
+static void HideWindow(HWND hwnd) {
+    if (IsWindow(hwnd)) {
+        ShowWindow(hwnd, SW_HIDE);
+    }
+}
+
+static void CheckAndHide(HWND hwnd) {
+    WCHAR title[256];
+    if (GetWindowTextW(hwnd, title, ARRAYSIZE(title))) {
+        if (ShouldHideTitle(title)) {
+            HideWindow(hwnd);
+        }
+    }
+}
+
+static BOOL CALLBACK EnumProc(HWND hwnd, LPARAM lParam) {
+    CheckAndHide(hwnd);
+    return TRUE;
+}
+
+typedef HWND (WINAPI *CreateWindowExW_t)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int,
+                                         HWND, HMENU, HINSTANCE, LPVOID);
+CreateWindowExW_t pCreateWindowExW;
+
+HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
+                                 DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+                                 HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam) {
+    HWND hwnd = pCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
+                                 hWndParent, hMenu, hInstance, lpParam);
+    if (hwnd) {
+        if (ShouldHideTitle(lpWindowName)) {
+            HideWindow(hwnd);
+        } else {
+            CheckAndHide(hwnd);
+        }
+    }
+    return hwnd;
+}
+
+typedef BOOL (WINAPI *SetWindowTextW_t)(HWND, LPCWSTR);
+SetWindowTextW_t pSetWindowTextW;
+
+BOOL WINAPI SetWindowTextW_Hook(HWND hwnd, LPCWSTR lpString) {
+    if (ShouldHideTitle(lpString)) {
+        HideWindow(hwnd);
+    }
+    return pSetWindowTextW(hwnd, lpString);
+}
+
+BOOL Wh_ModInit(void) {
+    EnumWindows(EnumProc, 0);
+    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook, (void**)&pCreateWindowExW);
+    Wh_SetFunctionHook((void*)SetWindowTextW, (void*)SetWindowTextW_Hook, (void**)&pSetWindowTextW);
+    return TRUE;
+}
+
+void Wh_ModUninit(void) {
+}
+


### PR DESCRIPTION
## Summary
- Hide any window named "Büyüteç" or "Magnifier" to keep Magnifier running without UI
- Document headless mode behavior in README

## Testing
- `g++ -std=c++17 -c magnify_noui.cpp` *(fails: fatal error: windhawk.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba67f5c5a4832b80035aef59763535