### PR TITLE
Hide Magnifier and Büyüteç windows for Magnifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 Magnifier Headless Mode
 
-Blocks all Magnifier window creation, keeping only zoom functionality
+Windhawk mod that hides the Magnifier user interface window
+named "Büyüteç" or "Magnifier", leaving only the zoom functionality active.

--- a/magnify_noui.cpp
+++ b/magnify_noui.cpp
@@ -11,3 +11,65 @@
 // @exclude         ^(?!.*magnify.exe)
 // @compilerOptions -luser32 -lkernel32
 // ==/WindhawkMod==
+
+#include <windows.h>
+#include <windhawk.h>
+
+// Store handle of the Magnifier window so we can block attempts to show it
+static HWND g_magnifierWindow = NULL;
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+static CreateWindowExW_t pCreateWindowExW;
+
+// Intercept window creation and hide the Magnifier UI window ("Büyüteç" or "Magnifier")
+HWND WINAPI CreateWindowExW_Hook(
+    DWORD dwExStyle,
+    LPCWSTR lpClassName,
+    LPCWSTR lpWindowName,
+    DWORD dwStyle,
+    int X,
+    int Y,
+    int nWidth,
+    int nHeight,
+    HWND hWndParent,
+    HMENU hMenu,
+    HINSTANCE hInstance,
+    LPVOID lpParam) {
+    // Call the original function first
+    HWND hwnd = pCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle,
+                                X, Y, nWidth, nHeight, hWndParent, hMenu,
+                                hInstance, lpParam);
+
+    if (hwnd && lpWindowName &&
+        (wcscmp(lpWindowName, L"Büyüteç") == 0 ||
+         wcscmp(lpWindowName, L"Magnifier") == 0)) {
+        g_magnifierWindow = hwnd;
+        // Ensure the window stays hidden
+        ShowWindow(hwnd, SW_HIDE);
+    }
+
+    return hwnd;
+}
+
+using ShowWindow_t = decltype(&ShowWindow);
+static ShowWindow_t pShowWindow;
+
+// Prevent the window from being shown later on
+BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
+    if (hWnd == g_magnifierWindow) {
+        nCmdShow = SW_HIDE;
+    }
+    return pShowWindow(hWnd, nCmdShow);
+}
+
+void Wh_ModInit() {
+    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook,
+                       (void**)&pCreateWindowExW);
+    Wh_SetFunctionHook((void*)ShowWindow, (void*)ShowWindow_Hook,
+                       (void**)&pShowWindow);
+}
+
+void Wh_ModUninit() {
+    g_magnifierWindow = NULL;
+}
+


### PR DESCRIPTION
## Summary
- Hide Magnifier UI windows titled "Büyüteç" or "Magnifier" via creation hook.
- Document the mod's support for both window titles.

## Testing
- `g++ -c magnify_noui.cpp` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba63c7a5c4832b8cdc5b72d0b46fcd