### PR TITLE
Move magnifier window hiding to Wh_ModAfterInit callback

### DIFF
--- a/magnifier-headless.wh.cpp
+++ b/magnifier-headless.wh.cpp
@@ -259,22 +259,21 @@ BOOL Wh_ModInit() {
 
     g_bInitialized = TRUE;
 
-    // Hide any magnifier windows that already exist
-    EnumWindows(EnumWindowsProc_HideMagnifier, 0);
-
     Wh_Log(L"Magnifier Headless: Initialization complete");
     return TRUE;
 }
 
+// Called by Windhawk after all hooks are activated and original function
+// pointers are valid. Safe to call ShowWindow_Original here.
+void Wh_ModAfterInit() {
+    Wh_Log(L"Magnifier Headless: Hiding existing magnifier windows...");
+    EnumWindows(EnumWindowsProc_HideMagnifier, 0);
+}
+
 void Wh_ModUninit() {
-    Wh_Log(L"Magnifier Headless: Uninitializing...");
-
-    g_bInitialized = FALSE;
-
-    if (g_hHostWnd) {
-        DestroyWindow(g_hHostWnd);
-        g_hHostWnd = NULL;
-    }
-
-    Wh_Log(L"Magnifier Headless: Uninitialization complete");
+    Wh_Log(L"Magnifier Headless: Uninitializing - terminating process for clean state");
+    // Restoring state (unhiding windows, unregistering class, destroying the
+    // host window from the correct thread) is not feasible. Terminate so that
+    // magnify.exe can be restarted cleanly without the mod.
+    TerminateProcess(GetCurrentProcess(), 0);
 }


### PR DESCRIPTION
## Summary
Refactored the magnifier headless mod to move window hiding logic from initialization to a new `Wh_ModAfterInit` callback, and simplified the uninitialization process to terminate the current process for clean state restoration.

## Key Changes
- **Moved window hiding logic**: Relocated `EnumWindows(EnumWindowsProc_HideMagnifier, 0)` from `Wh_ModInit` to a new `Wh_ModAfterInit` callback function
  - This ensures the operation runs after all hooks are activated and original function pointers are valid
  - Allows safe calling of `ShowWindow_Original` during window enumeration
  
- **Simplified uninitialization**: Changed `Wh_ModUninit` to call `TerminateProcess` instead of manually cleaning up resources
  - Removes manual window destruction and state restoration logic
  - Ensures magnify.exe can be restarted cleanly without the mod
  - Avoids threading issues with window cleanup from incorrect thread context

## Implementation Details
The `Wh_ModAfterInit` callback is specifically designed for operations that depend on hooks being fully initialized, making it the appropriate place for window enumeration that may trigger hooked functions.

https://claude.ai/code/session_016jDzeyvogYdfzTWZP5uAsD